### PR TITLE
Fix for malfunctioning cop:

### DIFF
--- a/.gemspec
+++ b/.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rubocop",             "0.82.0"
+  spec.add_dependency "rubocop",             "0.89.0"
   spec.add_dependency "rubocop-rspec",       "1.33.0"
   spec.add_dependency "rubocop-performance", "1.5.2"
 end

--- a/default.yml
+++ b/default.yml
@@ -166,7 +166,7 @@ Lint/UnusedMethodArgument:
 
 Lint/BinaryOperatorWithIdenticalOperands:
   Description: 'This cop checks for places where binary operator has identical operands.'
-  Enabled: true
+  Enabled: false
 
 Lint/UselessElseWithoutRescue:
   Description: 'Checks for useless `else` in `begin..end` without `rescue`.'

--- a/default.yml
+++ b/default.yml
@@ -164,8 +164,8 @@ Lint/UnusedMethodArgument:
     - app/smart/**/*.rb      # Smart does this by design w/ example resources
     - app/decorators/**/*.rb # to_json(*args) shouldn't trigger this
 
-Lint/UselessComparison:
-  Description: 'Checks for comparison of something with itself.'
+Lint/BinaryOperatorWithIdenticalOperands:
+  Description: 'This cop checks for places where binary operator has identical operands.'
   Enabled: true
 
 Lint/UselessElseWithoutRescue:

--- a/lib/ut/style_ruby/version.rb
+++ b/lib/ut/style_ruby/version.rb
@@ -3,7 +3,7 @@
 module UT
   module StyleRuby
     module Version
-      VERSION = "0.0.1"
+      VERSION = "0.0.2"
     end
   end
 end


### PR DESCRIPTION
Rubocop broke in my editor:

```
Lint: executing /Users/cdimartino/.gem/ruby/2.7.1/bin/rubocop -s
/Users/cdimartino/source/orders/app/models/panel.rb -f json -l...
Error: The `Lint/UselessComparison` cop has been removed since it has
been superseded by `Lint/BinaryOperatorWithIdenticalOperands`. Please
use `Lint/BinaryOperatorWithIdenticalOperands` instead.
(obsolete configuration found in
/Users/cdimartino/.gem/ruby/2.7.1/gems/ut-rubocop-0.0.1/default.yml,
please update it)
```