### PR TITLE
Allow Style/FrozenStringLiteralComment to be auto-corrected

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -23,6 +23,17 @@ inherit_gem:
     - default.yml
 ```
 
+## Updating Gem
+
+- Increase version number in `lib/ut/style_ruby/version.rb` in your PR.
+- After merging to main, tag the current HEAD with the version number chosen: `git tag v0.0.x`
+- Build the gem: `gem build .gemspec`
+- Push gem to rubygems.org: `gem push ut-rubocop-0.0.x.gem`
+
+The gem is now updated on [rubygems.org](https://rubygems.org/gems/ut-rubocop).
+
+_Note that you will need to be added as a maintainer of the gem to be able to push it._
+
 ## Usage
 
 `bundle exec rubocop`

--- a/default.yml
+++ b/default.yml
@@ -262,7 +262,6 @@ Style/For:
 
 Style/FrozenStringLiteralComment:
   Enabled: true
-  AutoCorrect: false
 
 Layout/InitialIndentation:
   Enabled: true

--- a/lib/ut/style_ruby/version.rb
+++ b/lib/ut/style_ruby/version.rb
@@ -3,7 +3,7 @@
 module UT
   module StyleRuby
     module Version
-      VERSION = "0.0.3"
+      VERSION = "0.0.4"
     end
   end
 end


### PR DESCRIPTION
Took me a long time to realize why the auto-correct on orders wasn't working. (Rubocop doesn't tell you the config is disabling the option.)