### PR TITLE
Remove rails-based cop configs

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -181,43 +181,6 @@ Lint/Void:
 
 # ------------------------------------ /Lints -------------------------------------------
 
-# ------------------------------------ Rails --------------------------------------------
-Rails/Exit:
-  Description: >-
-                  Favor `fail`, `break`, `return`, etc. over `exit` in
-                  application or library code outside of Rake files to avoid
-                  exits during unit testing or running in production.
-  Enabled: true
-
-Rails/Output:
-  Description: 'Checks for calls to puts, print, etc.'
-  Enabled: true
-  Exclude:
-    - db/migrate/*.rb
-    - lib/perform_deployment.rb
-    - lib/asset_manifest.rb
-    - lib/chores/log.rb
-    - lib/generators/chore/chore_generator.rb
-
-Rails/PluralizationGrammar:
-  Description: 'Checks for incorrect grammar when using methods like `3.day.ago`.'
-  Enabled: true
-
-Rails/ScopeArgs:
-  Description: 'Checks the arguments of ActiveRecord scopes.'
-  Enabled: true
-
-Rails/UniqBeforePluck:
-  Description: 'Prefer the use of uniq or distinct before pluck.'
-  Enabled: true
-
-Rails/ActiveRecordAliases:
-  Description: 'Checks that ActiveRecord aliases are not used. The direct method names are more clear and easier to read.'
-  Enabled: true
-
-# ------------------------------------ /Rails --------------------------------------------
-
-
 # ------------------------------------ Style --------------------------------------------
 Style/ArrayJoin:
   Enabled: true

--- a/lib/ut/style_ruby/version.rb
+++ b/lib/ut/style_ruby/version.rb
@@ -3,7 +3,7 @@
 module UT
   module StyleRuby
     module Version
-      VERSION = "0.0.4"
+      VERSION = "0.0.5"
     end
   end
 end


### PR DESCRIPTION
# Purpose
This gem should be usable in projects that do not include rails - these rules belong in https://github.com/usertesting/ut_rubocop_rails instead.

# implementation
* remove the rails-based cop config
* bump the version to 0.0.5